### PR TITLE
Change valid versions of Chai as a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "load-grunt-tasks": "^1.0.0"
   },
   "peerDependencies": {
-    "chai": "< 2"
+    "chai": "<1.10.0 || >1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/prodatakey/dirty-chai",
   "devDependencies": {
-    "chai": "<1.10.0",
+    "chai": "< 2",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/prodatakey/dirty-chai",
   "devDependencies": {
-    "chai": "< 2",
+    "chai": "<1.10.0 || >1.10.0",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "load-grunt-tasks": "^1.0.0"
   },
   "peerDependencies": {
-    "chai": "<1.10.0"
+    "chai": "< 2"
   }
 }


### PR DESCRIPTION
Instead of limiting this to < 1.10.0 of Chai it should be limited to what it is valid with. In this case I've made it valid with anything less than version 2. Currently, this setting prevents use of this plugin with the latest version of Chai even though it should work as expected. This PR changes the Peer Dependency requirement as well as the Dev Dependency version of Chai to make it compatible with the latest version(s) of Chai.