### PR TITLE
Changes to allow use with chai-2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/prodatakey/dirty-chai",
   "devDependencies": {
-    "chai": "<1.10.0 || >1.10.0 <2",
+    "chai": "<1.10.0 || >1.10.0 <3",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
@@ -31,6 +31,6 @@
     "load-grunt-tasks": "^1.0.0"
   },
   "peerDependencies": {
-    "chai": "<1.10.0 || >1.10.0 <2"
+    "chai": "<1.10.0 || >1.10.0 <3"
   }
 }


### PR DESCRIPTION
Chai 2 removes `addChainableNoop`, which was introduced in chai-1.10.0. The [release notes for 2.0.0](https://github.com/chaijs/chai/blob/master/ReleaseNotes.md#200--2015-02-09) specifically points folks to use dirty-chai, so it would be good if the peer deps were compatible :-)