### PR TITLE
Update package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "keywords": [
     "chai",
+    "chai-plugin",
+    "browser",
     "testing"
   ],
   "author": "Joshua Perry <josh@pdk.io>",


### PR DESCRIPTION
See https://github.com/chaijs/chai-docs/pull/34 for more.

> If you're wondering why I want you to add these keywords, here is the reasoning for each one:
> 
> - `chai-plugin` will let us index your plugin on the next version of the website. If you don't add this to your package.json, you wont be listed on our plugins page.
> - `browser` will let us know that your plugin supports the browser. Please don't add this keyword if you don't support the browser. If you don't add it we'll assume the plugin does not support browsers.

This partially fixes #15, a new release is required to fully fix it.