### PR TITLE
Update for Chai v4

### DIFF
--- a/test/dirty-chai.spec.js
+++ b/test/dirty-chai.spec.js
@@ -43,7 +43,9 @@ describe('dirty chai', function() {
     describe('when false expression', function() {
       it('should assert non-function at chain end', function() {
         var assertion = expect(true).to.not.be.ok.and.not;
-        shouldFail(assertion.equal.bind(assertion, false), /expected true to be falsy/);
+        shouldFail(function () {
+          assertion.equal.call(assertion, false);
+        }, /expected true to be falsy/);
       });
 
       it('should assert with custom message at chain end', function() {
@@ -124,9 +126,9 @@ describe('dirty chai', function() {
 
     it('should convert property to a chainable method', function() {
       var prop = Object.getOwnPropertyDescriptor(chai.Assertion.prototype, 'neverFail');
-      chai.Assertion.prototype.should.have.a.property('neverFail').and.should.be.a('function');
+      (new chai.Assertion({})).should.have.a.property('neverFail').and.be.a('function');
       prop.should.have.property('get').and.be.a('function');
-      prop.get.call(new chai.Assertion({})).should.be.a('function');
+      ((new chai.Assertion({}).neverFail)).should.be.a('function');
     });
 
     it('should call assertion', function() {


### PR DESCRIPTION
DO NOT MERGE. Chai v4 isn't released yet, version numbers in package.json still need updating.

I'm just going through some popular Chai plugins to see how much breakage there is when used with the upcoming Chai v4 release. It doesn't look like it breaks any of dirty-chai's functionality, but it does cause two tests to fail. I don't think these failed tests will impact end users of dirty-chai; they are specific to how assertions were being performed on actual Chai Assertion objects.

The test on line 127 fails for two reasons:

1. The `property` assertion is actually triggering the getter for `chai.Assertion.prototype['neverFail']`, which is causing a `__flag` property to be created directly on `chai.Assertion.prototype` when setting the `defer` flag, which is in turn wreaking havoc on all future assertions. (This was happening in v3.5 too, just not with the same consequences).
1. in Chai v4, assertions return a new `Assertion` object with the flags transferred over. Therefore, the second `should` switches the context to the new `Assertion` object instead of the `neverFail` function, causing the assertion to fail.

The test on line 129 fails because the `new chai.Assertion({})` that gets passed to the `neverFail` getter via `call` is actually a proxified `Assertion` object, which then gets double-wrapped inside another proxy inside of the `addChainableMethod` function. Therefore, when `should` is called, it gets called twice (the second time is from within the proxy getter of the first call), and the end result is that the context is the `Assertion` object instead of the `neverFail` function.

This PR refactors the tests slightly so that they work in both chai v3.5 and chai v4.0