### PR TITLE
README.md: fix "use with chai-as-promised" displayed incorrectly + make the "caveats" sections linkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following built-in assertions are modified by this plugin to now use the fun
 
 ## Caveats
 
-**Always terminate with a function**
+### Always terminate with a function
 
 These forms can also be mixed, but the chain must always be terminated in the function form or assertions up to that point in the chain will not execute.
 
@@ -54,7 +54,7 @@ expect(true).to.be.true.and.not.false();
 expect(true).to.be.true().and.not.false();
 ```
 
-**Chaining length/arguments**
+### Chaining length/argument
 
 This breaks both the `length` and `arguments` asserts when they are in the chain following any other assertion. To work around this limitation, do the `length` or `arguments` asserts first in the chain or just do multiple assertion statements.
 
@@ -66,7 +66,7 @@ myArray.should.exist();
 myArray.should.have.length(3);
 ```
 
-** use with chai-as-promised **
+### use with chai-as-promised
 
 If you're using chai-as-promised, you should `.use` chai-as-promised before dirty-chai:
 


### PR DESCRIPTION
Found by reading the README.